### PR TITLE
Keyvault samples unique key names

### DIFF
--- a/sdk/android/azure-samples/src/main/java/com/azure/android/keyvault/certificates/BackupAndRestoreOperationsKeyvaultCertificates.java
+++ b/sdk/android/azure-samples/src/main/java/com/azure/android/keyvault/certificates/BackupAndRestoreOperationsKeyvaultCertificates.java
@@ -53,6 +53,8 @@ public class BackupAndRestoreOperationsKeyvaultCertificates {
                 .credential(clientSecretCredential)
             .buildClient();
 
+        String certificateName = "certificateName" + System.currentTimeMillis();
+
         // Let's create a self-signed certificate valid for 1 year. If the certificate already exists in the key vault,
         // then a new version of the certificate is created.
         CertificatePolicy policy = new CertificatePolicy("Self", "CN=SelfSignedJavaPkcs12")
@@ -64,7 +66,7 @@ public class BackupAndRestoreOperationsKeyvaultCertificates {
         tags.put("foo", "bar");
 
         SyncPoller<CertificateOperation, KeyVaultCertificateWithPolicy> certificatePoller =
-            certificateClient.beginCreateCertificate("certificateName", policy, true, tags);
+            certificateClient.beginCreateCertificate(certificateName, policy, true, tags);
         certificatePoller.waitUntil(LongRunningOperationStatus.SUCCESSFULLY_COMPLETED);
 
         KeyVaultCertificate cert = certificatePoller.getFinalResult();
@@ -72,7 +74,7 @@ public class BackupAndRestoreOperationsKeyvaultCertificates {
         // Backups are good to have, if in case certificates get accidentally deleted by you.
         // For long term storage, it is ideal to write the backup to a file.
         String backupFilePath = "YOUR_BACKUP_FILE_PATH";
-        byte[] certificateBackup = certificateClient.backupCertificate("certificateName");
+        byte[] certificateBackup = certificateClient.backupCertificate(certificateName);
 
         System.out.printf("Backed up certificate with back up blob length %d", certificateBackup.length);
 
@@ -80,7 +82,7 @@ public class BackupAndRestoreOperationsKeyvaultCertificates {
 
         // The certificate is no longer in use, so you delete it.
         SyncPoller<DeletedCertificate, Void> deletedCertificatePoller =
-            certificateClient.beginDeleteCertificate("certificateName");
+            certificateClient.beginDeleteCertificate(certificateName);
         // Deleted Certificate is accessible as soon as polling beings.
         PollResponse<DeletedCertificate> pollResponse = deletedCertificatePoller.poll();
 
@@ -93,7 +95,7 @@ public class BackupAndRestoreOperationsKeyvaultCertificates {
         Thread.sleep(30000);
 
         // If the vault is soft-delete enabled, then you need to purge the certificate as well for permanent deletion.
-        certificateClient.purgeDeletedCertificateWithResponse("certificateName", new Context("key1", "value1"));
+        certificateClient.purgeDeletedCertificateWithResponse(certificateName, new Context("key1", "value1"));
 
         // To ensure the certificate is purged server-side.
         Thread.sleep(15000);

--- a/sdk/android/azure-samples/src/main/java/com/azure/android/keyvault/certificates/HelloWorldKeyvaultCertificates.java
+++ b/sdk/android/azure-samples/src/main/java/com/azure/android/keyvault/certificates/HelloWorldKeyvaultCertificates.java
@@ -47,6 +47,9 @@ public class HelloWorldKeyvaultCertificates {
                 .credential(clientSecretCredential)
                 .buildClient();
 
+        String certificateName = "certificateName" + System.currentTimeMillis();
+        String myCertificate = "myCertificate" + System.currentTimeMillis();
+
         // Let's create a self-signed certificate valid for 1 year. If the certificate already exists in the key vault,
         // then a new version of the certificate is created.
         CertificatePolicy policy = new CertificatePolicy("Self", "CN=SelfSignedJavaPkcs12")
@@ -59,13 +62,13 @@ public class HelloWorldKeyvaultCertificates {
         tags.put("foo", "bar");
 
         SyncPoller<CertificateOperation, KeyVaultCertificateWithPolicy> certificatePoller =
-            certificateClient.beginCreateCertificate("certificateName", policy, true, tags);
+            certificateClient.beginCreateCertificate(certificateName, policy, true, tags);
         certificatePoller.waitUntil(LongRunningOperationStatus.SUCCESSFULLY_COMPLETED);
 
         KeyVaultCertificate cert = certificatePoller.getFinalResult();
 
         // Let's get the latest version of the certificate from the key vault.
-        KeyVaultCertificate certificate = certificateClient.getCertificate("certificateName");
+        KeyVaultCertificate certificate = certificateClient.getCertificate(certificateName);
 
         System.out.printf("Certificate is returned with name %s and secret id %s \n",
             certificate.getProperties().getName(), certificate.getSecretId());
@@ -90,19 +93,19 @@ public class HelloWorldKeyvaultCertificates {
         System.out.printf("Issuer retrieved with name %s and provider %s", myIssuer.getName(), myIssuer.getProvider());
 
         // Let's create a certificate signed by our issuer.
-        certificateClient.beginCreateCertificate("myCertificate",
+        certificateClient.beginCreateCertificate(myCertificate,
                 new CertificatePolicy("myIssuer", "CN=SelfSignedJavaPkcs12"), true, tags)
             .waitUntil(LongRunningOperationStatus.SUCCESSFULLY_COMPLETED);
 
         // Let's get the latest version of our certificate from the key vault.
-        KeyVaultCertificate myCert = certificateClient.getCertificate("myCertificate");
+        KeyVaultCertificate myCert = certificateClient.getCertificate(myCertificate);
 
         System.out.printf("Certificate is returned with name %s and secret id %s \n", myCert.getProperties().getName(),
             myCert.getSecretId());
 
         // The certificates and issuers are no longer needed, need to delete it from the key vault.
         SyncPoller<DeletedCertificate, Void> deletedCertificatePoller =
-            certificateClient.beginDeleteCertificate("certificateName");
+            certificateClient.beginDeleteCertificate(certificateName);
         // Deleted certificate is accessible as soon as polling beings.
         PollResponse<DeletedCertificate> pollResponse = deletedCertificatePoller.poll();
 
@@ -112,7 +115,7 @@ public class HelloWorldKeyvaultCertificates {
         deletedCertificatePoller.waitForCompletion();
 
         SyncPoller<DeletedCertificate, Void> deletedCertPoller =
-            certificateClient.beginDeleteCertificate("myCertificate");
+            certificateClient.beginDeleteCertificate(myCertificate);
         // Deleted certificate is accessible as soon as polling beings.
         PollResponse<DeletedCertificate> deletePollResponse = deletedCertPoller.poll();
 
@@ -130,7 +133,7 @@ public class HelloWorldKeyvaultCertificates {
         Thread.sleep(30000);
 
         // If the key vault is soft-delete enabled, then deleted certificates need to be purged for permanent deletion.
-        certificateClient.purgeDeletedCertificate("certificateName");
-        certificateClient.purgeDeletedCertificate("myCertificate");
+        certificateClient.purgeDeletedCertificate(certificateName);
+        certificateClient.purgeDeletedCertificate(myCertificate);
     }
 }

--- a/sdk/android/azure-samples/src/main/java/com/azure/android/keyvault/certificates/ListOperationsKeyvaultCertificates.java
+++ b/sdk/android/azure-samples/src/main/java/com/azure/android/keyvault/certificates/ListOperationsKeyvaultCertificates.java
@@ -44,6 +44,9 @@ public class ListOperationsKeyvaultCertificates {
                 .credential(clientSecretCredential)
                 .buildClient();
 
+        String certName = "certName" + System.currentTimeMillis();
+        String myCertificate = "myCertificate" + System.currentTimeMillis();
+
         // Let's create a self-signed certificate valid for 1 year. If the certificate already exists in the key vault,
         // then a new version of the certificate is created.
         CertificatePolicy policy = new CertificatePolicy("Self", "CN=SelfSignedJavaPkcs12");
@@ -51,7 +54,7 @@ public class ListOperationsKeyvaultCertificates {
         tags.put("foo", "bar");
 
         SyncPoller<CertificateOperation, KeyVaultCertificateWithPolicy> certificatePoller =
-            certificateClient.beginCreateCertificate("certName", policy, true, tags);
+            certificateClient.beginCreateCertificate(certName, policy, true, tags);
         certificatePoller.waitUntil(LongRunningOperationStatus.SUCCESSFULLY_COMPLETED);
 
         KeyVaultCertificate cert = certificatePoller.getFinalResult();
@@ -63,7 +66,7 @@ public class ListOperationsKeyvaultCertificates {
         System.out.printf("Issuer created with name %s and provider %s", myIssuer.getName(), myIssuer.getProvider());
 
         // Let's create a certificate signed by our issuer.
-        certificateClient.beginCreateCertificate("myCertificate",
+        certificateClient.beginCreateCertificate(myCertificate,
             new CertificatePolicy("myIssuer", "CN=SignedJavaPkcs12"), true, tags)
             .waitUntil(LongRunningOperationStatus.SUCCESSFULLY_COMPLETED);
 
@@ -78,7 +81,7 @@ public class ListOperationsKeyvaultCertificates {
         }
 
         // Let's list all certificate versions of the certificate.
-        for (CertificateProperties certificate : certificateClient.listPropertiesOfCertificateVersions("myCertificate")) {
+        for (CertificateProperties certificate : certificateClient.listPropertiesOfCertificateVersions(myCertificate)) {
             KeyVaultCertificate certificateWithAllProperties =
                 certificateClient.getCertificateVersion(certificate.getName(), certificate.getVersion());
 

--- a/sdk/android/azure-samples/src/main/java/com/azure/android/keyvault/certificates/ManagingDeletedCertificatesAsyncKeyvaultCertificates.java
+++ b/sdk/android/azure-samples/src/main/java/com/azure/android/keyvault/certificates/ManagingDeletedCertificatesAsyncKeyvaultCertificates.java
@@ -44,6 +44,8 @@ public class ManagingDeletedCertificatesAsyncKeyvaultCertificates {
                 .credential(clientSecretCredential)
                 .buildAsyncClient();
 
+        String certificateName = "certificateName" + System.currentTimeMillis();
+
         // Let's create a self-signed certificate valid for 1 year. If the certificate already exists in the key vault,
         // then a new version of the certificate is created.
         CertificatePolicy policy = new CertificatePolicy("Self", "CN=SelfSignedJavaPkcs12")
@@ -54,7 +56,7 @@ public class ManagingDeletedCertificatesAsyncKeyvaultCertificates {
         Map<String, String> tags = new HashMap<>();
         tags.put("foo", "bar");
 
-        certificateAsyncClient.beginCreateCertificate("certificateName", policy, true, tags)
+        certificateAsyncClient.beginCreateCertificate(certificateName, policy, true, tags)
             .subscribe(pollResponse -> {
                 System.out.println("---------------------------------------------------------------------------------");
                 System.out.println(pollResponse.getStatus());
@@ -65,7 +67,7 @@ public class ManagingDeletedCertificatesAsyncKeyvaultCertificates {
         Thread.sleep(22000);
 
         // The certificate is no longer needed, need to delete it from the key vault.
-        certificateAsyncClient.beginDeleteCertificate("certificateName")
+        certificateAsyncClient.beginDeleteCertificate(certificateName)
             .subscribe(pollResponse -> {
                 System.out.println("Delete Status: " + pollResponse.getStatus().toString());
                 System.out.println("Delete Certificate Name: " + pollResponse.getValue().getName());
@@ -77,7 +79,7 @@ public class ManagingDeletedCertificatesAsyncKeyvaultCertificates {
 
         // We accidentally deleted the certificate. Let's recover it.
         // A deleted certificate can only be recovered if the key vault is soft-delete enabled.
-        certificateAsyncClient.beginRecoverDeletedCertificate("certificateName")
+        certificateAsyncClient.beginRecoverDeletedCertificate(certificateName)
             .subscribe(pollResponse -> {
                 System.out.println("Recovery Status: " + pollResponse.getStatus().toString());
                 System.out.println("Recover Certificate Name: " + pollResponse.getValue().getName());
@@ -88,7 +90,7 @@ public class ManagingDeletedCertificatesAsyncKeyvaultCertificates {
         Thread.sleep(10000);
 
         // The certificate is no longer needed, need to delete it from the key vault.
-        certificateAsyncClient.beginDeleteCertificate("certificateName")
+        certificateAsyncClient.beginDeleteCertificate(certificateName)
             .subscribe(pollResponse -> {
                 System.out.println("Delete Status: " + pollResponse.getStatus().toString());
                 System.out.println("Delete Certificate Name: " + pollResponse.getValue().getName());
@@ -106,7 +108,7 @@ public class ManagingDeletedCertificatesAsyncKeyvaultCertificates {
         Thread.sleep(15000);
 
         // If the keyvault is soft-delete enabled, then deleted certificates need to be purged for permanent deletion.
-        certificateAsyncClient.purgeDeletedCertificateWithResponse("certificateName")
+        certificateAsyncClient.purgeDeletedCertificateWithResponse(certificateName)
             .subscribe(purgeResponse ->
                 System.out.printf("Purge Status response %d %n", purgeResponse.getStatusCode()));
 

--- a/sdk/android/azure-samples/src/main/java/com/azure/android/keyvault/keys/HelloWorldKeyvaultKeys.java
+++ b/sdk/android/azure-samples/src/main/java/com/azure/android/keyvault/keys/HelloWorldKeyvaultKeys.java
@@ -48,10 +48,12 @@ public class HelloWorldKeyvaultKeys {
             .credential(clientSecretCredential)
             .buildClient();
 
+        String helloCloudRsaKey = "HelloCloudRsaKey" + System.currentTimeMillis();
+
         // Let's create an RSA key valid for 1 year. If the key already exists in the key vault, then a new version of
         // the key is created.
         Response<KeyVaultKey> createKeyResponse =
-            keyClient.createRsaKeyWithResponse(new CreateRsaKeyOptions("HelloCloudRsaKey")
+            keyClient.createRsaKeyWithResponse(new CreateRsaKeyOptions(helloCloudRsaKey)
                 .setExpiresOn(OffsetDateTime.now().plusYears(1))
                 .setKeySize(2048), new Context("key1", "value1"));
 
@@ -59,7 +61,7 @@ public class HelloWorldKeyvaultKeys {
         Log.i(TAG, String.format("Create Key operation succeeded with status code %s \n", createKeyResponse.getStatusCode()));
 
         // Let's get the RSA key from the key vault.
-        KeyVaultKey cloudRsaKey = keyClient.getKey("HelloCloudRsaKey");
+        KeyVaultKey cloudRsaKey = keyClient.getKey(helloCloudRsaKey);
 
         Log.i(TAG, String.format("Key is returned with name %s and type %s \n", cloudRsaKey.getName(),
             cloudRsaKey.getKeyType()));
@@ -75,12 +77,12 @@ public class HelloWorldKeyvaultKeys {
         // We need the RSA key with bigger key size, so you want to update the key in key vault to ensure it has the
         // required size. Calling createRsaKey() on an existing key creates a new version of the key in the key vault
         // with the new specified size.
-        keyClient.createRsaKey(new CreateRsaKeyOptions("HelloCloudRsaKey")
+        keyClient.createRsaKey(new CreateRsaKeyOptions(helloCloudRsaKey)
             .setExpiresOn(OffsetDateTime.now().plusYears(1))
             .setKeySize(4096));
 
         // The RSA key is no longer needed, need to delete it from the key vault.
-        SyncPoller<DeletedKey, Void> rsaDeletedKeyPoller = keyClient.beginDeleteKey("HelloCloudRsaKey");
+        SyncPoller<DeletedKey, Void> rsaDeletedKeyPoller = keyClient.beginDeleteKey(helloCloudRsaKey);
         PollResponse<DeletedKey> pollResponse = rsaDeletedKeyPoller.poll();
         DeletedKey rsaDeletedKey = pollResponse.getValue();
 
@@ -94,7 +96,7 @@ public class HelloWorldKeyvaultKeys {
         Thread.sleep(30000);
 
         // If the keyvault is soft-delete enabled, then deleted keys need to be purged for permanent deletion.
-        keyClient.purgeDeletedKey("HelloCloudRsaKey");
+        keyClient.purgeDeletedKey(helloCloudRsaKey);
         Log.i(TAG, "HelloCloudRsaKey purged from vault");
     }
 }

--- a/sdk/android/azure-samples/src/main/java/com/azure/android/keyvault/keys/KeyRotationAsyncKeyvaultKeys.java
+++ b/sdk/android/azure-samples/src/main/java/com/azure/android/keyvault/keys/KeyRotationAsyncKeyvaultKeys.java
@@ -46,7 +46,7 @@ public class KeyRotationAsyncKeyvaultKeys {
             .buildAsyncClient();
 
         // Let's create an RSA key.
-        String keyName = "MyKey";
+        String keyName = "MyKey" + System.currentTimeMillis();
         keyAsyncClient.createRsaKey(new CreateRsaKeyOptions(keyName).setKeySize(2048))
             .subscribe(originalKey ->
                 Log.i(TAG, String.format("Key created with name: %s, and type: %s%n", originalKey.getName(),

--- a/sdk/android/azure-samples/src/main/java/com/azure/android/keyvault/secrets/BackupAndRestoreOperationsKeyvaultSecrets.java
+++ b/sdk/android/azure-samples/src/main/java/com/azure/android/keyvault/secrets/BackupAndRestoreOperationsKeyvaultSecrets.java
@@ -51,22 +51,24 @@ public class BackupAndRestoreOperationsKeyvaultSecrets {
                 .credential(clientSecretCredential)
                 .buildClient();
 
+        String storageAccountPassword = "StorageAccountPassword" + System.currentTimeMillis();
+
         // Let's create secrets holding storage account credentials valid for 1 year. If the secret already exists in
         // the key vault, then a new version of the secret is created.
-        client.setSecret(new KeyVaultSecret("StorageAccountPassword", "f4G34fMh8v-fdsgjsk2323=-asdsdfsdf")
+        client.setSecret(new KeyVaultSecret(storageAccountPassword, "f4G34fMh8v-fdsgjsk2323=-asdsdfsdf")
             .setProperties(new SecretProperties()
                 .setExpiresOn(OffsetDateTime.now().plusYears(1))));
 
         // Backups are good to have, if in case secrets get accidentally deleted by you.
         // For long term storage, it is ideal to write the backup to a file.
         String backupFilePath = "YOUR_BACKUP_FILE_PATH";
-        byte[] secretBackup = client.backupSecret("StorageAccountPassword");
+        byte[] secretBackup = client.backupSecret(storageAccountPassword);
 
         writeBackupToFile(secretBackup, backupFilePath);
 
         // The storage account secret is no longer in use, so you delete it.
         SyncPoller<DeletedSecret, Void> deletedStorageSecretPoller =
-            client.beginDeleteSecret("StorageAccountPassword");
+            client.beginDeleteSecret(storageAccountPassword);
         PollResponse<DeletedSecret>  pollResponse = deletedStorageSecretPoller.poll();
         DeletedSecret deletedStorageSecret = pollResponse.getValue();
 
@@ -80,7 +82,7 @@ public class BackupAndRestoreOperationsKeyvaultSecrets {
         Thread.sleep(30000);
 
         // If the vault is soft-delete enabled, then you need to purge the secret as well for permanent deletion.
-        client.purgeDeletedSecret("StorageAccountPassword");
+        client.purgeDeletedSecret(storageAccountPassword);
 
         // To ensure the secret is purged server-side.
         Thread.sleep(15000);

--- a/sdk/android/azure-samples/src/main/java/com/azure/android/keyvault/secrets/HelloWorldKeyvaultSecrets.java
+++ b/sdk/android/azure-samples/src/main/java/com/azure/android/keyvault/secrets/HelloWorldKeyvaultSecrets.java
@@ -42,14 +42,16 @@ public class HelloWorldKeyvaultSecrets {
                 .credential(clientSecretCredential)
                 .buildClient();
 
+        String bankAccountPassword = "BankAccountPassword" + System.currentTimeMillis();
+
         // Let's create a secret holding bank account credentials valid for 1 year. If the secret already exists in the
         // key vault, then a new version of the secret is created.
-        secretClient.setSecret(new KeyVaultSecret("BankAccountPassword", "f4G34fMh8v")
+        secretClient.setSecret(new KeyVaultSecret(bankAccountPassword, "f4G34fMh8v")
             .setProperties(new SecretProperties()
                 .setExpiresOn(OffsetDateTime.now().plusYears(1))));
 
         // Let's get the bank secret from the key vault.
-        KeyVaultSecret bankSecret = secretClient.getSecret("BankAccountPassword");
+        KeyVaultSecret bankSecret = secretClient.getSecret(bankAccountPassword);
 
         Log.i(TAG, String.format("Secret is returned with name %s and value %s \n", bankSecret.getName(), bankSecret.getValue()));
 
@@ -65,13 +67,13 @@ public class HelloWorldKeyvaultSecrets {
         // Bank forced a password update for security purposes. Let's change the value of the secret in the key vault.
         // To achieve this, we need to create a new version of the secret in the key vault. The update operation cannot
         // change the value of the secret.
-        secretClient.setSecret(new KeyVaultSecret("BankAccountPassword", "bhjd4DDgsa")
+        secretClient.setSecret(new KeyVaultSecret(bankAccountPassword, "bhjd4DDgsa")
             .setProperties(new SecretProperties()
                 .setExpiresOn(OffsetDateTime.now().plusYears(1))));
 
         // The bank account was closed, need to delete its credentials from the key vault.
         SyncPoller<DeletedSecret, Void> deletedBankSecretPoller =
-            secretClient.beginDeleteSecret("BankAccountPassword");
+            secretClient.beginDeleteSecret(bankAccountPassword);
         PollResponse<DeletedSecret> deletedBankSecretPollResponse = deletedBankSecretPoller.poll();
 
         Log.i(TAG, "Deleted Date " + deletedBankSecretPollResponse.getValue().getDeletedOn().toString());
@@ -81,6 +83,6 @@ public class HelloWorldKeyvaultSecrets {
         deletedBankSecretPoller.waitForCompletion();
 
         // If the key vault is soft-delete enabled, then deleted secrets need to be purged for permanent deletion.
-        secretClient.purgeDeletedSecret("BankAccountPassword");
+        secretClient.purgeDeletedSecret(bankAccountPassword);
     }
 }

--- a/sdk/android/azure-samples/src/main/java/com/azure/android/keyvault/secrets/ListOperationsAsyncKeyvaultSecrets.java
+++ b/sdk/android/azure-samples/src/main/java/com/azure/android/keyvault/secrets/ListOperationsAsyncKeyvaultSecrets.java
@@ -41,9 +41,12 @@ public class ListOperationsAsyncKeyvaultSecrets {
                 .credential(clientSecretCredential)
                 .buildAsyncClient();
 
+        String bankAccountPassword = "BankAccountPassword" + System.currentTimeMillis();
+        String storageAccountPassword = "StorageAccountPassword" + System.currentTimeMillis();
+
         // Let's create secrets holding storage and bank accounts credentials valid for 1 year. If the secret already
         // exists in the key vault, then a new version of the secret is created.
-        secretAsyncClient.setSecret(new KeyVaultSecret("BankAccountPassword", "f4G34fMh8v")
+        secretAsyncClient.setSecret(new KeyVaultSecret(bankAccountPassword, "f4G34fMh8v")
                 .setProperties(new SecretProperties()
                     .setExpiresOn(OffsetDateTime.now().plusYears(1))))
             .subscribe(secretResponse ->
@@ -52,7 +55,7 @@ public class ListOperationsAsyncKeyvaultSecrets {
 
         Thread.sleep(2000);
 
-        secretAsyncClient.setSecret(new KeyVaultSecret("StorageAccountPassword", "f4G34fMh8v-fdsgjsk2323=-asdsdfsdf")
+        secretAsyncClient.setSecret(new KeyVaultSecret(storageAccountPassword, "f4G34fMh8v-fdsgjsk2323=-asdsdfsdf")
                 .setProperties(new SecretProperties()
                     .setExpiresOn(OffsetDateTime.now().plusYears(1))))
             .subscribe(secretResponse ->
@@ -75,7 +78,7 @@ public class ListOperationsAsyncKeyvaultSecrets {
         // The bank account password got updated, so you want to update the secret in key vault to ensure it reflects
         // the new password. Calling setSecret on an existing secret creates a new version of the secret in the key
         // vault with the new value.
-        secretAsyncClient.setSecret(new KeyVaultSecret("BankAccountPassword", "sskdjfsdasdjsd")
+        secretAsyncClient.setSecret(new KeyVaultSecret(bankAccountPassword, "sskdjfsdasdjsd")
             .setProperties(new SecretProperties()
                 .setExpiresOn(OffsetDateTime.now().plusYears(1))))
             .subscribe(secretResponse ->
@@ -86,7 +89,7 @@ public class ListOperationsAsyncKeyvaultSecrets {
 
         // You need to check all the different values your bank account password secret had previously. Lets print all
         // the versions of this secret.
-        secretAsyncClient.listPropertiesOfSecretVersions("BankAccountPassword")
+        secretAsyncClient.listPropertiesOfSecretVersions(bankAccountPassword)
             .subscribe(secret ->
                 secretAsyncClient.getSecret(secret.getName(), secret.getVersion())
                     .subscribe(secretResponse ->


### PR DESCRIPTION
Keyvault tests and samples could fail if aprevious run had failed between key delete and completion of key purge due to duplicate name error.  Resolved by adding systemtime to key name strings

closes IanZYYap/android-testing-for-azure-sdk#52